### PR TITLE
Rebase nspire/main.c on newest unix/main.c

### DIFF
--- a/nspire/main.c
+++ b/nspire/main.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -30,90 +30,122 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <unistd.h>
 #include <ctype.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <errno.h>
 #include <libndls.h>
 
-#include "mpconfig.h"
-#include "nlr.h"
-#include "misc.h"
-#include "qstr.h"
-#include "lexer.h"
-#include "parse.h"
-#include "obj.h"
-#include "compile.h"
-#include "runtime0.h"
-#include "runtime.h"
-#include "repl.h"
-#include "gc.h"
+#include "py/mpstate.h"
+#include "py/nlr.h"
+#include "py/compile.h"
+#include "py/runtime.h"
+#include "py/builtin.h"
+#include "py/repl.h"
+#include "py/gc.h"
+#include "py/stackctrl.h"
+#include "py/mphal.h"
+#include "py/mpthread.h"
+#include "extmod/misc.h"
 #include "genhdr/mpversion.h"
 #include "input.h"
-#include "stackctrl.h"
 
 // Command line options, with their defaults
-//uint emit_opt = MP_EMIT_OPT_NATIVE_PYTHON;
-uint emit_opt = MP_EMIT_OPT_NONE;
+STATIC uint emit_opt = MP_EMIT_OPT_NONE;
 
 #if MICROPY_ENABLE_GC
-// 3 MiB 
-long heap_size = 2*1024*1024;
+// Heap size of GC heap (if enabled)
+// Make it larger on a 64 bit machine, because pointers are larger.
+long heap_size = 1024*1024 * (sizeof(mp_uint_t) / 4);
 #endif
 
 void nsp_texture_init();
 void nsp_texture_deinit();
 
-static bool should_exit = false;
-static uint exit_val;
 
-STATIC void stderr_print_strn(void *env, const char *str, mp_uint_t len) {
+STATIC void stderr_print_strn(void *env, const char *str, size_t len) {
     (void)env;
-    fwrite(str, len, 1, stderr);
+    ssize_t dummy = write(STDERR_FILENO, str, len);
+    mp_uos_dupterm_tx_strn(str, len);
+    (void)dummy;
 }
 
 const mp_print_t mp_stderr_print = {NULL, stderr_print_strn};
 
-// returns standard error codes: 0 for success, 1 for all other errors
-STATIC int execute_from_lexer(mp_lexer_t *lex, mp_parse_input_kind_t input_kind, bool is_repl) {
-    if (lex == NULL) {
-        return 1;
+#define FORCED_EXIT (0x100)
+// If exc is SystemExit, return value where FORCED_EXIT bit set,
+// and lower 8 bits are SystemExit value. For all other exceptions,
+// return 1.
+STATIC int handle_uncaught_exception(mp_obj_base_t *exc) {
+    // check for SystemExit
+    if (mp_obj_is_subclass_fast(MP_OBJ_FROM_PTR(exc->type), MP_OBJ_FROM_PTR(&mp_type_SystemExit))) {
+        // None is an exit value of 0; an int is its value; anything else is 1
+        mp_obj_t exit_val = mp_obj_exception_get_value(MP_OBJ_FROM_PTR(exc));
+        mp_int_t val = 0;
+        if (exit_val != mp_const_none && !mp_obj_get_int_maybe(exit_val, &val)) {
+            val = 1;
+        }
+        return FORCED_EXIT | (val & 255);
     }
 
-    // execute it
+    // Report all other exceptions
+    mp_obj_print_exception(&mp_stderr_print, MP_OBJ_FROM_PTR(exc));
+    return 1;
+}
+
+#define LEX_SRC_STR (1)
+#define LEX_SRC_VSTR (2)
+#define LEX_SRC_FILENAME (3)
+#define LEX_SRC_STDIN (4)
+
+// Returns standard error codes: 0 for success, 1 for all other errors,
+// except if FORCED_EXIT bit is set then script raised SystemExit and the
+// value of the exit is in the lower 8 bits of the return value
+STATIC int execute_from_lexer(int source_kind, const void *source, mp_parse_input_kind_t input_kind, bool is_repl) {
+
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
+        // create lexer based on source kind
+        mp_lexer_t *lex;
+        if (source_kind == LEX_SRC_STR) {
+            const char *line = source;
+            lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, line, strlen(line), false);
+        } else if (source_kind == LEX_SRC_VSTR) {
+            const vstr_t *vstr = source;
+            lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, vstr->buf, vstr->len, false);
+        } else if (source_kind == LEX_SRC_FILENAME) {
+            lex = mp_lexer_new_from_file((const char*)source);
+        } else { // LEX_SRC_STDIN
+            lex = mp_lexer_new_from_fd(MP_QSTR__lt_stdin_gt_, 0, false);
+        }
+
         qstr source_name = lex->source_name;
+
         #if MICROPY_PY___FILE__
-            if (input_kind == MP_PARSE_FILE_INPUT) {
+        if (input_kind == MP_PARSE_FILE_INPUT) {
             mp_store_global(MP_QSTR___file__, MP_OBJ_NEW_QSTR(source_name));
         }
         #endif
 
-        mp_parse_tree_t pn = mp_parse(lex, input_kind);
+        mp_parse_tree_t parse_tree = mp_parse(lex, input_kind);
 
-        mp_obj_t module_fun = mp_compile(&pn, source_name, emit_opt, is_repl);
+        mp_obj_t module_fun = mp_compile(&parse_tree, source_name, emit_opt, is_repl);
 
-        if (module_fun == mp_const_none) {
-            // compile error
-            return 1;
+        // execute it
+        mp_call_function_0(module_fun);
+        // check for pending exception
+        if (MP_STATE_VM(mp_pending_exception) != MP_OBJ_NULL) {
+            mp_obj_t obj = MP_STATE_VM(mp_pending_exception);
+            MP_STATE_VM(mp_pending_exception) = MP_OBJ_NULL;
+            nlr_raise(obj);
         }
 
-        mp_call_function_0(module_fun);
         nlr_pop();
         return 0;
     } else {
         // uncaught exception
-        // check for SystemExit
-        mp_obj_t exc = (mp_obj_t)nlr.ret_val;
-        if (mp_obj_is_subclass_fast(mp_obj_get_type(exc), &mp_type_SystemExit)) {
-			exit_val = mp_obj_get_int(mp_obj_exception_get_value(exc));
-			should_exit = 1;
-        }
-        else
-			mp_obj_print_exception(&mp_stderr_print, exc);
-
-        return 1;
+        return handle_uncaught_exception(nlr.ret_val);
     }
 }
 
@@ -131,30 +163,31 @@ STATIC char *strjoin(const char *s1, int sep_char, const char *s2) {
     return s;
 }
 
-STATIC void do_repl(void) {
-    printf("Micro Python " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "\n");
+STATIC int do_repl(void) {
+    mp_hal_stdout_tx_str("MicroPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "\n");
 
-    while(!should_exit) {
+    // use simple readline
+
+    for (;;) {
         char *line = prompt(">>> ");
-	if(!line)
-		return;
-
+        if (line == NULL) {
+            // EOF
+            return 0;
+        }
         while (mp_repl_continue_with_input(line)) {
             char *line2 = prompt("... ");
-            if (!line2)
+            if (line2 == NULL) {
                 break;
-
+            }
             char *line3 = strjoin(line, '\n', line2);
             free(line);
             free(line2);
             line = line3;
         }
 
-        if(strcmp("quit", line) == 0) {
-            should_exit = true;
-        } else {
-            mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, line, strlen(line), false);
-            execute_from_lexer(lex, MP_PARSE_SINGLE_INPUT, true);
+        int ret = execute_from_lexer(LEX_SRC_STR, line, MP_PARSE_SINGLE_INPUT, true);
+        if (ret & FORCED_EXIT) {
+            return ret;
         }
 
         free(line);
@@ -162,16 +195,38 @@ STATIC void do_repl(void) {
 }
 
 STATIC int do_file(const char *file) {
-    mp_lexer_t *lex = mp_lexer_new_from_file(file);
-    return execute_from_lexer(lex, MP_PARSE_FILE_INPUT, false);
+    return execute_from_lexer(LEX_SRC_FILENAME, file, MP_PARSE_FILE_INPUT, false);
 }
 
-/*STATIC int do_str(const char *str) {
-    mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, str, strlen(str), false);
-    return execute_from_lexer(lex, MP_PARSE_SINGLE_INPUT, false);
-}*/
+/*
+STATIC int do_str(const char *str) {
+    return execute_from_lexer(LEX_SRC_STR, str, MP_PARSE_FILE_INPUT, false);
+}
+*/
+
+STATIC void set_sys_argv(char *argv[], int argc, int start_arg) {
+    for (int i = start_arg; i < argc; i++) {
+        mp_obj_list_append(mp_sys_argv, MP_OBJ_NEW_QSTR(qstr_from_str(argv[i])));
+    }
+}
+
+MP_NOINLINE int main_(int argc, char **argv);
 
 int main(int argc, char **argv) {
+    #if MICROPY_PY_THREAD
+    mp_thread_init();
+    #endif
+    // We should capture stack top ASAP after start, and it should be
+    // captured guaranteedly before any other stack variables are allocated.
+    // For this, actual main (renamed main_) should not be inlined into
+    // this function. main_() itself may have other functions inlined (with
+    // their own stack variables), that's why we need this main/main_ split.
+    mp_stack_ctrl_init();
+    return main_(argc, argv);
+}
+
+MP_NOINLINE int main_(int argc, char **argv) {
+    mp_stack_set_limit(40000 * (BYTES_PER_WORD / 4));
 
     //Disable output buffering, otherwise interactive mode becomes useless
     setbuf(stdout, NULL);
@@ -195,9 +250,10 @@ int main(int argc, char **argv) {
     mp_init();
 
     uint path_num = 2;
-    mp_obj_list_init(mp_sys_path, path_num);
+    mp_obj_list_init(MP_OBJ_TO_PTR(mp_sys_path), path_num);
     mp_obj_t *path_items;
     mp_obj_list_get(mp_sys_path, &path_num, &path_items);
+    mp_obj_list_init(MP_OBJ_TO_PTR(mp_sys_argv), 0);
 
     path_items[0] = MP_OBJ_NEW_QSTR(MP_QSTR_);
     path_items[1] = MP_OBJ_NEW_QSTR(qstr_from_str("/documents/ndless"));
@@ -208,21 +264,27 @@ int main(int argc, char **argv) {
     int ret = NOTHING_EXECUTED;
 
     for (int a = 1; a < argc; a++) {
-        // Set base dir of the script as first entry in sys.path
-        char *p = strrchr(argv[a], '/');
-        path_items[0] = MP_OBJ_NEW_QSTR(qstr_from_strn(argv[a], p - argv[a]));
-
-        for (int i = a; i < argc; i++) {
-            mp_obj_list_append(mp_sys_argv, MP_OBJ_NEW_QSTR(qstr_from_str(argv[i])));
+        char *pathbuf = malloc(PATH_MAX);
+        char *basedir = realpath(argv[a], pathbuf);
+        if (basedir == NULL) {
+            mp_printf(&mp_stderr_print, "%s: can't open file '%s': [Errno %d] %s\n", argv[0], argv[a], errno, strerror(errno));
+            // CPython exits with 2 in such case
+            ret = 2;
+            break;
         }
 
+        // Set base dir of the script as first entry in sys.path
+        char *p = strrchr(basedir, '/');
+        path_items[0] = MP_OBJ_NEW_QSTR(qstr_from_strn(basedir, p - basedir));
+        free(pathbuf);
+
+        set_sys_argv(argv, argc, a);
         ret = do_file(argv[a]);
         break;
     }
 
     if (ret == NOTHING_EXECUTED) {
-        do_repl();
-        ret = 0;
+        ret = do_repl();
     }
     else
     {
@@ -236,10 +298,7 @@ int main(int argc, char **argv) {
 
     nsp_texture_deinit();
 
-    if(should_exit)
-        return exit_val;
-	
-    return ret;
+    return ret & 0xff;
 }
 
 mp_import_stat_t mp_import_stat(const char *path) {


### PR DESCRIPTION
This is mostly based on reviewing the diff between the two and applying all
changes from unix/main.c. A few large blocks behind #ifdef's which aren't
applicable (like readline) are deleted to make the diff against the old
nspire/main.c a bit smaller.

This fixes the "Unknown NLR" issues which happened on exit with the latest
release (2014-10-27) and on every input with an updated micropython but old
main.c.

The new handling for sys.path and sys.argv seem to yield the same result than
the old one did when opening a .py.tns file.

Fixes #6.